### PR TITLE
Fix README typo and server start error method

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ Example:
 ```
   hapi: {
     port: 5000,
-    ip: '192.168.0.5'
-  }ik
- 
+    ip: '127.0.0.1'
+  }
+
  ```
 
 * Update Snowflake ```src/lib/config.js``` w/ same ip from step above
@@ -243,7 +243,7 @@ Example:
 ```
   HAPI: {
     local: {
-      url: 'http://192.168.0.5:5000'
+      url: 'http://127.0.0.1:5000'
     },
     remote: {
       url: 'enter your remote url here'

--- a/server.js
+++ b/server.js
@@ -7,9 +7,9 @@
 /**
  *  Hapi will be the NodeJS server.
  *  I figure if WalMart, the largest retailer in the world, uses it,
- *  it will work for me.  
+ *  it will work for me.
  *
- * From the command line, run ```npm start``` 
+ * From the command line, run ```npm start```
  *
  *  Hapi is configured in this import
  */
@@ -23,7 +23,11 @@ require('./src/database/mongodb');
 /**
  * When hapi starts up, some info is displayed
  */
-HapiServer.start(function () {
+HapiServer.start(function (err) {
+  if (err) {
+    console.log(err);
+    return;
+  };
   console.log('Server is running: ' + HapiServer.info.uri);
 });
 


### PR DESCRIPTION
In first time start, it didn't return any message from browser(http://192.168.0.5:5000)
So I add this error display and find a typo :)

before
```
> showflake-hapi-openshift@0.0.1 start /Users/josh/lab/snowflake-hapi-openshift
> cp ./README.md src/docs && node server.js

Server is running: http://Joshde-MacBook-Pro.local:5000
```

after
```
> showflake-hapi-openshift@0.0.1 start /Users/josh/lab/snowflake-hapi-openshift
> cp ./README.md src/docs && node server.js

{ Error: listen EADDRNOTAVAIL 192.168.0.5:5000
    at Object.exports._errnoException (util.js:1008:11)
    at exports._exceptionWithHostPort (util.js:1031:20)
    at Server._listen2 (net.js:1240:19)
    at listen (net.js:1289:10)
    at net.js:1399:9
    at _combinedTickCallback (internal/process/next_tick.js:77:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:577:11)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
  code: 'EADDRNOTAVAIL',
  errno: 'EADDRNOTAVAIL',
  syscall: 'listen',
  address: '192.168.0.5',
  port: 5000 }
```